### PR TITLE
added instagram accounts search

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ $ instagram-screen-scrape comments --post 0qPcnuI4Pr
 {"id":"948824521079751272","username":"k.kate","time":1427328718,"text":"Macarons or a Petri dish full of cells? ¯\\_(ツ)_/¯"}]
 ```
 
+Let's not forget about scraping accounts:
+
+```bash
+$ instagram-screen-scrape accounts --query carrotcreative
+[{"id":3007271,"username":"carrotcreative","profile_picture":"https://scontent-yyz1-1.cdninstagram.com/t51.2885-19/928950_798424113611469_2009622893_a.jpg","full_name":"carrotcreative","follower_count":15183,"is_private":false,"is_verified":false},
+{"id":3249857133,"username":"carrotcreativestudio","profile_picture":"https://scontent-yyz1-1.cdninstagram.com/t51.2885-19/s150x150/13355608_515624698629721_1281958434_a.jpg","full_name":"Carrot Creative Studios","follower_count":27,"is_private":false,"is_verified":false},
+{"id":373795157,"username":"carrotcreativedev","profile_picture":"https://scontent-yyz1-1.cdninstagram.com/t51.2885-19/11906329_960233084022564_1448528159_a.jpg","full_name":"carrot devops","follower_count":3,"is_private":false,"is_verified":false}]
+```
+
 By default, there is 1 line per post, making it easy to pipe into other tools. The following example uses `wc -l` to count how many posts are returned. As you can see, I don't post much.
 
 ```bash

--- a/lib/account.schema.json
+++ b/lib/account.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer"
+    },
+    "username": {
+      "type": "string"
+    },
+    "profile_picture": {
+      "type": "string"
+    },
+    "full_name": {
+      "type": "string"
+    },
+    "follower_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "is_private": {
+      "type": "boolean"
+    },
+    "is_verified": {
+      "type": "boolean"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "username"
+  ]
+}

--- a/lib/accounts.coffee
+++ b/lib/accounts.coffee
@@ -42,7 +42,7 @@ class InstagramAccounts extends Readable
       @push(null)
       return
 
-    # hasMoreUsers = false
+    hasMoreUsers = false
     foundAccounts = 0
 
     # we hold one post in a buffer because we need something to send directly
@@ -53,15 +53,15 @@ class InstagramAccounts extends Readable
       @emit('error', err)
     ).on('data', (raw) =>
       # if the request returned some profiles, be happy and stop searching
-      hasMoreUsers = true
+      hasMoreUsers = false
 
       if foundAccounts >= @limit
         hasMoreUsers = false
         # console.log 'foundAccounts', foundAccounts, @limit
-        @destroy()
+        # @destroy()
 
       account =
-        user_id: raw.user.pk
+        id: raw.user.pk
         username: raw.user.username
         profile_picture: raw.user.profile_pic_url
         full_name: raw.user.full_name
@@ -76,9 +76,9 @@ class InstagramAccounts extends Readable
       if lastAccount? then @push(lastAccount)
       lastAccount = account
     ).on('end', =>
-      if foundAccounts < @limit then @_lock = false
+      if hasMoreUsers then @_lock = false
       if lastAccount? then @push(lastAccount)
-      if not foundAccounts >= @limit then @push(null)
+      if not hasMoreUsers then @push(null)
     )
 
   destroy: =>

--- a/lib/accounts.coffee
+++ b/lib/accounts.coffee
@@ -1,0 +1,96 @@
+# see http://r.va.gg/2014/06/why-i-dont-use-nodes-core-stream-module.html for
+# why we use readable-stream
+Readable = require 'readable-stream/readable'
+{jsonRequest} = require './util'
+
+###*
+ * Make a request for a Instagram page, parse the response, and get all the
+   posts.
+ * @param {String} query
+ * @return {Stream} A stream of profile data
+###
+getUsers = (query) ->
+  jsonRequest('users.*'
+    uri: "https://www.instagram.com/web/search/topsearch/?context=blended&query=#{query}"
+  )
+
+###*
+ * Stream that scrapes as many posts as possible for a given user.
+ * @param {String} options.query
+ * @param {String} options.limit max amount of results to grab (optional and not working atm)
+ * @return {Stream} A stream of post objects.
+###
+class InstagramAccounts extends Readable
+  _lock: false
+  # _minPostId: undefined
+
+  constructor: ({@query,@limit}) ->
+    # remove the explicit HWM setting when github.com/nodejs/node/commit/e1fec22
+    # is merged into readable-stream
+
+    super(highWaterMark: 16, objectMode: true)
+    @_readableState.destroyed = false
+    # console.log 'limit', {@limit}
+    # @limit = @limit || 10
+
+  _read: =>
+    # prevent additional requests from being made while one is already running
+    if @_lock then return
+    @_lock = true
+
+    if @_readableState.destroyed
+      @push(null)
+      return
+
+    # hasMoreUsers = false
+    foundAccounts = 0
+
+    # we hold one post in a buffer because we need something to send directly
+    # after we turn off the lock
+    lastAccount = undefined
+
+    getUsers(@query).on('error', (err) =>
+      @emit('error', err)
+    ).on('data', (raw) =>
+      # if the request returned some profiles, be happy and stop searching
+      hasMoreUsers = true
+
+      if foundAccounts >= @limit
+        hasMoreUsers = false
+        # console.log 'foundAccounts', foundAccounts, @limit
+        @destroy()
+
+      account =
+        user_id: raw.user.pk
+        username: raw.user.username
+        profile_picture: raw.user.profile_pic_url
+        full_name: raw.user.full_name
+        follower_count: raw.user.follower_count
+        is_private: raw.user.is_private
+        is_verified: raw.user.is_verified
+
+      ++foundAccounts
+
+      # @_minPostId = raw.id # only the last one really matters
+
+      if lastAccount? then @push(lastAccount)
+      lastAccount = account
+    ).on('end', =>
+      if foundAccounts < @limit then @_lock = false
+      if lastAccount? then @push(lastAccount)
+      if not foundAccounts >= @limit then @push(null)
+    )
+
+  destroy: =>
+    if @_readableState.destroyed then return
+    @_readableState.destroyed = true
+
+    @_destroy((err) =>
+      if (err) then @emit('error', err)
+      @emit('close')
+    )
+
+  _destroy: (cb) ->
+    process.nextTick(cb)
+
+module.exports = InstagramAccounts

--- a/lib/cli.coffee
+++ b/lib/cli.coffee
@@ -1,5 +1,6 @@
 InstagramPosts = require './posts'
 InstagramComments = require './comments'
+InstagramAccounts = require './accounts'
 packageInfo = require '../package'
 ArgumentParser = require('argparse').ArgumentParser
 JSONStream = require 'JSONStream'
@@ -36,6 +37,23 @@ subcommand.addArgument(
   help: 'Username of the account to scrape.'
 )
 
+subcommand = subparser.addParser(
+  'accounts'
+  description: 'Scrape accounts by query'
+  addHelp: true
+)
+subcommand.addArgument(
+  ['-q', '--query']
+  type: 'string'
+  help: 'Query string of the accounts to scrape.'
+)
+subcommand.addArgument(
+  ['-l', '--limit']
+  type: 'int'
+  defaultValue: 1
+  help: 'Limit number of pages to scrape'
+)
+
 argv = argparser.parseArgs()
 {subcommand} = argv
 delete argv.subcommand
@@ -43,6 +61,8 @@ delete argv.subcommand
 (
   if subcommand is 'posts'
     new InstagramPosts(argv)
+  else if subcommand is 'accounts'
+    new InstagramAccounts(argv)
   else # comments
     new InstagramComments(argv)
 ).pipe(

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -1,4 +1,5 @@
 module.exports = {
   InstagramPosts: require './posts'
   InstagramComments: require './comments'
+  InstagramAccounts: require './accounts'
 }

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -2,9 +2,10 @@
 isStream = require 'isstream'
 should = require 'should'
 
-{InstagramPosts, InstagramComments} = require '../lib'
+{InstagramPosts, InstagramComments, InstagramAccounts} = require '../lib'
 postSchema = require '../lib/post.schema'
 commentSchema = require '../lib/comment.schema'
+accountSchema = require '../lib/account.schema'
 
 describe 'post stream', ->
   before ->
@@ -32,6 +33,36 @@ describe 'post stream', ->
     for post in @posts
       (post.time > year2000).should.be.true
       (post.time < year3000).should.be.true # instagram should be dead by then
+
+describe 'account stream', ->
+  before ->
+    @stream = new InstagramAccounts(query: 'slang800')
+    @accounts = []
+
+  it 'should return a stream', ->
+    isStream(@stream).should.be.true
+
+  it 'should stream account objects', (done) ->
+    @timeout(4000)
+    @stream.on('data', (account) =>
+      validate(account, accountSchema).errors.should.eql([])
+      @accounts.push account
+    ).on('end', =>
+      @accounts.length.should.be.above(0)
+      done()
+    )
+
+  it 'should include a valid username for each account', ->
+
+    for acc in @accounts
+      acc.username.should.be.an.instanceOf(String)
+      acc.username.length.should.be.above(0)
+
+  it 'should include a valid id for each account', ->
+
+    for acc in @accounts
+      acc.id.should.be.an.instanceOf(Number)
+      acc.id.should.be.above(0)
 
 describe 'comment stream', ->
   before ->


### PR DESCRIPTION
example: `instagram-screen-scrape accounts --query piamuehlenbeck`

NOTE: --limit does not work atm as my comfort level with coffeescript/stream is a tad limited. Currently all available results (up to 54) are returned
